### PR TITLE
Add registration code for material alternative oreDict

### DIFF
--- a/src/main/kotlin/hiiragi283/material/init/RMItems.kt
+++ b/src/main/kotlin/hiiragi283/material/init/RMItems.kt
@@ -73,6 +73,23 @@ object RMItems : IRMEntry<Item> {
             share?.let { shareOredict(oredict, it) }
         }
 
+        fun shareMaterialOredict(material1: String, material2: String) {
+            OreDictionary.getOres("dust$material1").forEach { OreDictionary.registerOre("dust$material2", it) }
+            OreDictionary.getOres("dustTiny$material1").forEach { OreDictionary.registerOre("dustTiny$material2", it) }
+            OreDictionary.getOres("ingot$material1").forEach { OreDictionary.registerOre("ingot$material2", it) }
+            OreDictionary.getOres("nugget$material1").forEach { OreDictionary.registerOre("nugget$material2", it) }
+            OreDictionary.getOres("block$material1").forEach { OreDictionary.registerOre("block$material2", it) }
+            OreDictionary.getOres("plate$material1").forEach { OreDictionary.registerOre("plate$material2", it) }
+            OreDictionary.getOres("gear$material1").forEach { OreDictionary.registerOre("gear$material2", it) }
+            OreDictionary.getOres("dust$material2").forEach { OreDictionary.registerOre("dust$material1", it) }
+            OreDictionary.getOres("dustTiny$material2").forEach { OreDictionary.registerOre("dustTiny$material1", it) }
+            OreDictionary.getOres("ingot$material2").forEach { OreDictionary.registerOre("ingot$material1", it) }
+            OreDictionary.getOres("nugget$material2").forEach { OreDictionary.registerOre("nugget$material1", it) }
+            OreDictionary.getOres("block$material2").forEach { OreDictionary.registerOre("block$material1", it) }
+            OreDictionary.getOres("plate$material2").forEach { OreDictionary.registerOre("plate$material1", it) }
+            OreDictionary.getOres("gear$material2").forEach { OreDictionary.registerOre("gear$material1", it) }
+        }
+
         registerOredict("dustGunpowder", Items.GUNPOWDER, share = "gunpowder")
         registerOredict("dustSugar", Items.SUGAR, share = "sugar")
         registerOredict("gemCharcoal", Items.COAL, 1, share = "charcoal")
@@ -82,6 +99,9 @@ object RMItems : IRMEntry<Item> {
 
         shareOredict("dustSaltpeter", "dustNiter")
         shareOredict("fuelCoke", "gemCoke")
+
+        shareMaterialOredict("Aluminium", "Aluminum")
+        shareMaterialOredict("Uranium238", "Uranium")
     }
 
     override fun registerRecipe() {


### PR DESCRIPTION
- `fun shareMaterialOredict(material1: String, material2: String)`を追加
  - この関数は表記揺れのある素材に対してdustTiny/dust/ingot/nugget/block/gear/plateを相互登録し、どちらも使えるようにします 
    - _Aluminium_ (RagiMaterials)と _Aluminum_ (Thermal/Immersive)
    - _Uranium238_ (RagiMaterials)と _Uranium_ (Immersive)
  
![2023-06-18_20 02 56](https://github.com/Hiiragi283/RagiMaterials/assets/90126004/ad0cf242-38b3-46a1-8e36-082bf45a343b)
![2023-06-18_20 03 05](https://github.com/Hiiragi283/RagiMaterials/assets/90126004/e7108bc3-21a3-40ac-8984-57810b030382)
